### PR TITLE
Harden Github Action configuration

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,7 +5,8 @@ on:
     branches: [main]
 
 permissions:
-  contents: write
+  contents: read
+  id-token: write
 
 jobs:
   build-test-publish:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: write
+
 jobs:
   build-test-publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,9 @@ name: CI
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
+
+permissions:
+  contents: read
 
 jobs:
   build-and-test:
@@ -15,7 +16,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Clean install
         run: |

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "MCP for Devvit things",
   "license": "BSD-3-Clause",
   "author": "Marcus Wood",
-  "bugs": "https://github.com/modelcontextprotocol/servers/issues",
+  "bugs": "https://github.com/reddit/devvit-mcp/issues",
   "type": "module",
   "bin": {
     "devvit-mcp": "dist/index.js"


### PR DESCRIPTION
Potential fix for [https://github.com/reddit/devvit-mcp/security/code-scanning/2](https://github.com/reddit/devvit-mcp/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the minimal permissions required. Based on the workflow's steps:
- `contents: read` is sufficient for most steps, such as checking out the repository and running tests.
- `id-token: write` is required for `npm public --provenance` to allow Github to do the necessary song and dance

The `permissions` block will be added at the root level to apply to all jobs in the workflow. This ensures that the workflow has the least privileges necessary to complete its tasks.
